### PR TITLE
run blue-green only for production urls

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -26,8 +26,8 @@ export async function middleware(req: NextRequest) {
   if (process.env.NODE_ENV !== "production") {
     return NextResponse.next();
   }
-  // We only run blue-green deployments when accesing from production urls
-  if (req.nextUrl.hostname !== process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+  // We skip blue-green when accesing from deployment urls
+  if (req.nextUrl.hostname === process.env.VERCEL_URL) {
     return NextResponse.next();
   }
   // We only want to run blue-green for GET requests that are for HTML documents.

--- a/middleware.ts
+++ b/middleware.ts
@@ -26,6 +26,10 @@ export async function middleware(req: NextRequest) {
   if (process.env.NODE_ENV !== "production") {
     return NextResponse.next();
   }
+  // We only run blue-green deployments when accesing from production urls
+  if (req.nextUrl.hostname !== process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return NextResponse.next();
+  }
   // We only want to run blue-green for GET requests that are for HTML documents.
   if (req.method !== "GET") {
     return NextResponse.next();


### PR DESCRIPTION
When accessing a deployment URL directly the blue-green rerouting mechanism would run and the assets for the page would fail half of the time.

To fix this we check if the hostname is the deployment url by using `VERCEL_URL` that's a deployment variable included in every deployment (as mentioned [here](https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables)) 